### PR TITLE
adding quotes around dictionary

### DIFF
--- a/git-fat
+++ b/git-fat
@@ -212,7 +212,7 @@ class GitFat(object):
         try:
             initial_output = subprocess.check_output(cmd)
         except json.decoder.JSONDecodeError:
-            initial_output = {}
+            initial_output = '{}'
 
         processed = json.loads(initial_output)
         for item in processed.get("Contents", []):


### PR DESCRIPTION
There are missing quotation marks around the "initial_output"  json.loads requires a string input. 
@weswhet suggested I push this back to you. 